### PR TITLE
Add dark mode w/ Dark Reader compatibility

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -51,5 +51,6 @@ Contributors:
   Ramiro Araujo <rama.araujo@gmail.com> (github: ramiroaraujo)
   Daniel Skogly <daniel@pnkt.no> (github: poacher2k)
   Matt Wanchap <matt@wanchap.com> (github: mwanchap)
+  Leo Solidum <leo.g.solidum@gmail.com> (github: leosolid)
 
 Feel free to add real names in addition to GitHub usernames.

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -431,28 +431,33 @@ iframe.vimiumUIComponentReactivated {
   border: 5px solid yellow;
 }
 
-/* Dark mode CSS */
+/* Dark mode CSS for options page and exclusions */
 
 @media (prefers-color-scheme: dark) {
-  body {
-    filter: sepia(5%) invert(90%);
+  body.vimiumBody {
+    background-color: #292a2d;
+    color: white;
   }
 
-  body.themedBackground {
-    background-color: #242424;
+  body.vimiumBody a,
+  body.vimiumBody a:visited {
+    color: #8ab4f8;
   }
 
-  div#vomnibar, div#vimiumHelpDialogContainer, div.vimiumHUD {
-    box-shadow: 0px 2px 10px white;
+  body.vimiumBody textarea,
+  body.vimiumBody input {
+    background-color: #1d1d1f;
+    border-color: #1d1d1f;
+    color: #e8eaed;
   }
 
-  @-moz-document url-prefix() {
-    div.vimiumHUD {
-      position: inherit;
-    }
+  body.vimiumBody div.example {
+    color: #9aa0a6;
   }
 
-  img.vomnibarIcon {
-    filter: invert(100%);
+  body.vimiumBody div#state,
+  body.vimiumBody div#footer {
+    background-color: #202124;
+    border-color: rgba(255, 255, 255, 0.1);
   }
 }

--- a/pages/blank.html
+++ b/pages/blank.html
@@ -24,6 +24,6 @@
     <link rel="stylesheet" type="text/css" href="../content_scripts/vimium.css" />
 
   </head>
-  <body class="themedBackground">
+  <body class="vimiumBody">
   </body>
 </html>

--- a/pages/options.html
+++ b/pages/options.html
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="options.js"></script>
   </head>
 
-  <body class="themedBackground">
+  <body class="vimiumBody">
     <div id="wrapper">
       <header>Vimium Options</header>
       <table id="options">

--- a/pages/popup.html
+++ b/pages/popup.html
@@ -53,7 +53,7 @@
     <script src="../lib/settings.js"></script>
     <script src="options.js"></script>
   </head>
-  <body class="themedBackground">
+  <body class="vimiumBody">
     <div id="state"></div>
 
     <div id="exclusionScrollBox">

--- a/pages/vomnibar.css
+++ b/pages/vomnibar.css
@@ -148,3 +148,59 @@
 .vomnibarNoInsertText {
   visibility: hidden;
 }
+
+/* Dark Vomnibar */
+
+
+@media (prefers-color-scheme: dark) {
+  #vomnibar {
+    border: 1px solid rgba(0, 0, 0, 0.7);
+    border-radius: 6px;
+  }
+
+  #vomnibar .vomnibarSearchArea {
+    background-color: #35363a;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  #vomnibar input {
+    background-color: #202124;
+    color: white;
+    border: none;
+  }
+
+  #vomnibar ul {
+    background-color: #202124;
+  }
+
+  #vomnibar li {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  #vomnibar li.vomnibarSelected {
+    background-color: #37383a;
+  }
+
+  #vomnibar li .vomnibarUrl {
+    white-space: nowrap;
+    color: #5ca1f7;
+  }
+
+  #vomnibar li em,
+  #vomnibar li .vomnibarTitle {
+    color: white;
+  }
+
+  #vomnibar li .vomnibarSource {
+    color: #9aa0a6;
+  }
+
+  #vomnibar li .vomnibarMatch {
+    color: white;
+  }
+
+  #vomnibar li em .vomnibarMatch,
+  #vomnibar li .vomnibarTitle .vomnibarMatch {
+    color: white;
+  }
+}


### PR DESCRIPTION
This PR adds dark mode CSS that is compatible with the Dark Reader extension as requested in PR philc/vimium#3402. Dark mode is enabled when the user's system preference is set to dark as described [here](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).
